### PR TITLE
adding jawsdb credentials

### DIFF
--- a/config/config.json
+++ b/config/config.json
@@ -2,7 +2,7 @@
   "development": {
     "username": "root",
     "password": null,
-    "database": "database_development",
+    "database": "homestead_db",
     "host": "127.0.0.1",
     "dialect": "mysql"
   },
@@ -14,10 +14,6 @@
     "dialect": "mysql"
   },
   "production": {
-    "username": "root",
-    "password": null,
-    "database": "database_production",
-    "host": "127.0.0.1",
-    "dialect": "mysql"
+    "use_env_variable":"JAWSDB_URL"
   }
 }

--- a/config/config.json
+++ b/config/config.json
@@ -2,7 +2,7 @@
   "development": {
     "username": "root",
     "password": null,
-    "database": "homestead_db",
+    "database": "homestead",
     "host": "127.0.0.1",
     "dialect": "mysql"
   },


### PR DESCRIPTION
jawsdb creds are held within the .env file that is ignored.

they are passed to our config file as an environment variable.