### PR TITLE
Change community to event

### DIFF
--- a/views/partials/nav.handlebars
+++ b/views/partials/nav.handlebars
@@ -53,21 +53,8 @@
               <li class="nav-item">
                 <a class="nav-link" href="/account">Account</a>
               </li>
-              <li class="nav-item active has-child">
-                <a class="nav-link" href="/community">Community</a>
-                <!-- 1st level -->
-                <ul class="child">
-                  <li class="nav-item">
-                    <a href="/events" class="nav-link">Events</a>
-                  </li>
-                  <li class="nav-item">
-                    <a href="/classes" class="nav-link">Classes</a>
-                  </li>
-                  <li class="nav-item">
-                    <a href="/meetups" class="nav-link">Meetups</a>
-                  </li>
-                </ul>
-                <!-- end 1st level -->
+              <li class="nav-item active">
+                <a class="nav-link" href="/events">Events</a>
               </li>
               <li class="nav-item active has-child">
                 <a class="nav-link" href="/classified">Classifieds</a>


### PR DESCRIPTION
Removed extra tabs from the navigation bar, so now we only have events between account and classifieds.